### PR TITLE
Bump BaseElement for SSR support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enhance/base-element": "^1.3.0",
+        "@enhance/base-element": "^1.3.1",
         "@enhance/custom-element-mixin": "^1.2.1",
         "@enhance/event-handler-mixin": "^1.0.2",
         "@enhance/morphdom-mixin": "^1.1.1",
-        "@enhance/shadow-element-mixin": "^1.0.0",
+        "@enhance/shadow-element-mixin": "^1.0.1",
         "@enhance/template-mixin": "^1.0.1"
       },
       "devDependencies": {
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@enhance/base-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@enhance/base-element/-/base-element-1.3.0.tgz",
-      "integrity": "sha512-CAcKqBIHN71vDMEL49xbXei3pO5AP/FT9tmyljeqOvDxMD6k3Obsn+UOxorYSE+JxBVIEVXs/xNDxZ+n2selkA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@enhance/base-element/-/base-element-1.3.1.tgz",
+      "integrity": "sha512-Uhtc4XONdxAP+IyqPn+rhZhb3xYpJqBCvETK8rU/7ve7054URZdmRi6XhdrFJwpO1oVRz/an1iK9k6T1RGUbcA=="
     },
     "node_modules/@enhance/custom-element-mixin": {
       "version": "1.2.1",
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@enhance/shadow-element-mixin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@enhance/shadow-element-mixin/-/shadow-element-mixin-1.0.0.tgz",
-      "integrity": "sha512-8+52EyYztY986+e5seNTkQaiDm56usxGAk94DiOG9zRAU6aSw4spOKD6yUTFlhT1clp/WaKrJwjM6X38m1iUAQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@enhance/shadow-element-mixin/-/shadow-element-mixin-1.0.1.tgz",
+      "integrity": "sha512-NhVyQvilnTrpzhsuuLZsxJWBarOZWD0E4dQO1b8BLUymPlbcNgLXSF0OxMb5wv+cImJibXOSai3IV2Zef+CfnQ=="
     },
     "node_modules/@enhance/store": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "rollup": "^3.29.4"
   },
   "dependencies": {
-    "@enhance/base-element": "^1.3.0",
+    "@enhance/base-element": "^1.3.1",
     "@enhance/custom-element-mixin": "^1.2.1",
     "@enhance/event-handler-mixin": "^1.0.2",
     "@enhance/morphdom-mixin": "^1.1.1",
-    "@enhance/shadow-element-mixin": "^1.0.0",
+    "@enhance/shadow-element-mixin": "^1.0.1",
     "@enhance/template-mixin": "^1.0.1"
   }
 }


### PR DESCRIPTION
Need to bump the version of BaseClass to 1.3.1 to pick up the shim for `customElements.get`